### PR TITLE
Create Initial File Structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Shrub -- A Command-Line Tool for Using GitHub
+
+Shrub is a command-line client-server tool for using GitHub. It is being
+developed as a final project for CS 377 (Software Security) at Drexel
+University. The puprose is not so much to create a useful product as to
+demonstrate some of the "sins" of software security and how they may be
+mitigated.
+
+This aaplication is used from a client's computer to access various
+GitHub API endpoints. Shrub uses a server application to actually
+format these requests and handle authentication for the user, such that
+a user who can SSH authenticate against the Shrub server will have their
+GitHub credentials stored for them.
+

--- a/README.md
+++ b/README.md
@@ -6,9 +6,23 @@ University. The puprose is not so much to create a useful product as to
 demonstrate some of the "sins" of software security and how they may be
 mitigated.
 
-This aaplication is used from a client's computer to access various
+This aplication is used from a client's computer to access various
 GitHub API endpoints. Shrub uses a server application to actually
 format these requests and handle authentication for the user, such that
 a user who can SSH authenticate against the Shrub server will have their
 GitHub credentials stored for them.
 
+# Contents
+
+    shrub/
+    ├── README.md
+    ├── client
+    │   ├── shrub.py
+    │   └── shrublib
+    │       └── __init__.py
+    └── server
+        ├── shrubbery.py
+            └── shrubberylib
+                    └── __init__.py
+
+                    4 directories, 5 files

--- a/client/shrub.py
+++ b/client/shrub.py
@@ -1,0 +1,1 @@
+"""The Shrub client application."""

--- a/client/shrublib/__init__.py
+++ b/client/shrublib/__init__.py
@@ -1,0 +1,1 @@
+"""Shrub client package."""

--- a/server/shrubbery.py
+++ b/server/shrubbery.py
@@ -1,0 +1,1 @@
+"""Server application for Shrub."""

--- a/server/shrubberylib/__init__.py
+++ b/server/shrubberylib/__init__.py
@@ -1,0 +1,1 @@
+"""Shrub server-side package."""


### PR DESCRIPTION
These commits add a README and create an initial file structure for Shrub.

The idea is that all Shrub client code would belong in the `client` directory and all server-side code would reside in the `server` directory. The `shrub.py` and `shrubbery.py` files would be entry points to the application and most actual implementation would belong in the respective libraries.

I envision this working somewhat as follows:

1. A user calls `shrub.py` with some arbitrary arguments.
2. `shrub.py` parses those arguments, opens an ssh connection to _our_ server and executes a `shrubbery.py` command with appropriate arguments to generate the desired response.
3. `shrubbery.py` does its work and passes a response back to `shrub.py` along the ssh connection, which is then pretty-printed back to the client-side user.

This does not yet address how sins and mitigations would be highlighted/separated out, that is left for future work.